### PR TITLE
fix: add path validation in grade_eval.py

### DIFF
--- a/evals/flow-deep/grade_eval.py
+++ b/evals/flow-deep/grade_eval.py
@@ -84,8 +84,16 @@ def check(run_dir: Path, eval_id: int = 0) -> list[dict]:
     return results
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
 def main() -> int:
     run_dir = Path(sys.argv[1]).resolve()
+    try:
+        run_dir.relative_to(REPO_ROOT)
+    except ValueError:
+        print(f"拒绝：run_dir 必须位于仓库目录 {REPO_ROOT} 内（收到 {run_dir}）", file=sys.stderr)
+        return 2
     eval_id = int(sys.argv[2]) if len(sys.argv) > 2 else 0
     results = check(run_dir, eval_id)
     passed = sum(r["passed"] for r in results)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `evals/flow-deep/grade_eval.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `evals/flow-deep/grade_eval.py:88` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |

**Description**: The grade_eval.py script accepts a command-line argument for run_dir without validating that the resolved path is within expected boundaries. An attacker can provide path traversal sequences (e.g., '../../../etc/passwd') to read arbitrary files or write the grading.json output to arbitrary locations on the filesystem.

## Evidence

**Exploitation scenario**: An attacker with ability to execute grade_eval.py provides a malicious path argument:

1.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `evals/flow-deep/grade_eval.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
